### PR TITLE
Untangle ADC CLK blocking caps in schematic

### DIFF
--- a/ad9653_adc0.kicad_sch
+++ b/ad9653_adc0.kicad_sch
@@ -2280,7 +2280,7 @@
 	)
 	(wire
 		(pts
-			(xy 199.39 93.98) (xy 205.74 93.98)
+			(xy 204.47 91.44) (xy 205.74 91.44)
 		)
 		(stroke
 			(width 0)
@@ -2430,6 +2430,16 @@
 	)
 	(wire
 		(pts
+			(xy 204.47 93.98) (xy 199.39 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "281633a4-2b1b-4535-9829-2d7a3b67c269")
+	)
+	(wire
+		(pts
 			(xy 60.96 99.06) (xy 68.58 99.06)
 		)
 		(stroke
@@ -2467,16 +2477,6 @@
 			(type default)
 		)
 		(uuid "2c769272-22a4-4d79-a3b1-d3b856b7da1a")
-	)
-	(wire
-		(pts
-			(xy 213.36 93.98) (xy 213.36 91.44)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2e690fc2-d896-4b7a-8250-5e41cf9e3964")
 	)
 	(wire
 		(pts
@@ -2638,6 +2638,16 @@
 		)
 		(uuid "4430f9a3-dc05-459e-aa18-1cd800191e3d")
 	)
+	(wire
+		(pts
+			(xy 204.47 99.06) (xy 204.47 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "466fbd45-d14f-437c-9e65-f6e297868a6a")
+	)
 	(bus
 		(pts
 			(xy 85.09 121.92) (xy 85.09 124.46)
@@ -2647,6 +2657,16 @@
 			(type default)
 		)
 		(uuid "4817d599-e8e4-4999-9dd4-08d75a565801")
+	)
+	(wire
+		(pts
+			(xy 204.47 91.44) (xy 204.47 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "488f9912-4527-4f77-8dd6-3c12fb650d21")
 	)
 	(wire
 		(pts
@@ -2950,7 +2970,7 @@
 	)
 	(wire
 		(pts
-			(xy 199.39 96.52) (xy 205.74 96.52)
+			(xy 204.47 99.06) (xy 205.74 99.06)
 		)
 		(stroke
 			(width 0)
@@ -3077,6 +3097,16 @@
 			(type default)
 		)
 		(uuid "9ff61872-04bc-4eff-bee4-41b96bbc65bd")
+	)
+	(wire
+		(pts
+			(xy 204.47 96.52) (xy 199.39 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a04523f0-6a70-44d3-a1ae-00bf337423cd")
 	)
 	(bus
 		(pts
@@ -3377,16 +3407,6 @@
 			(type default)
 		)
 		(uuid "daf1cea3-61a5-4829-8ca8-963dc971778f")
-	)
-	(wire
-		(pts
-			(xy 213.36 96.52) (xy 213.36 99.06)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "db1477ef-0b5e-4ee8-affe-4e60047da99d")
 	)
 	(wire
 		(pts
@@ -4268,7 +4288,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 209.55 93.98 270)
+		(at 209.55 91.44 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4276,7 +4296,7 @@
 		(dnp no)
 		(uuid "1c234252-9d7c-4fe9-af25-8c97590a5312")
 		(property "Reference" "C211"
-			(at 209.55 97.79 90)
+			(at 213.36 92.71 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4284,7 +4304,7 @@
 			)
 		)
 		(property "Value" "10000PF"
-			(at 209.55 99.06 90)
+			(at 214.884 100.584 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4292,7 +4312,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric"
-			(at 205.74 94.9452 0)
+			(at 205.74 92.4052 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4301,7 +4321,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 209.55 93.98 0)
+			(at 209.55 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4310,7 +4330,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 209.55 93.98 0)
+			(at 209.55 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4319,7 +4339,7 @@
 			)
 		)
 		(property "Vendor" "digikey:445-2664-1-ND"
-			(at 115.57 -115.57 0)
+			(at 115.57 -118.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6458,7 +6478,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 209.55 96.52 270)
+		(at 209.55 99.06 270)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -6467,7 +6487,7 @@
 		(dnp no)
 		(uuid "d74e00c4-17e7-498e-90d0-da0b766dd5d5")
 		(property "Reference" "C212"
-			(at 209.55 92.71 90)
+			(at 213.614 97.79 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6475,7 +6495,7 @@
 			)
 		)
 		(property "Value" "10000PF"
-			(at 209.55 91.44 90)
+			(at 214.884 90.17 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6483,7 +6503,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric"
-			(at 205.74 95.5548 0)
+			(at 205.74 98.0948 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6492,7 +6512,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 209.55 96.52 0)
+			(at 209.55 99.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6501,7 +6521,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 209.55 96.52 0)
+			(at 209.55 99.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6510,7 +6530,7 @@
 			)
 		)
 		(property "Vendor" "digikey:445-2664-1-ND"
-			(at 113.03 306.07 0)
+			(at 113.03 308.61 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/ad9653_adc1.kicad_sch
+++ b/ad9653_adc1.kicad_sch
@@ -2154,7 +2154,7 @@
 	)
 	(wire
 		(pts
-			(xy 199.39 100.33) (xy 205.74 100.33)
+			(xy 204.47 102.87) (xy 205.74 102.87)
 		)
 		(stroke
 			(width 0)
@@ -2204,13 +2204,13 @@
 	)
 	(wire
 		(pts
-			(xy 213.36 100.33) (xy 213.36 102.87)
+			(xy 204.47 97.79) (xy 199.39 97.79)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "0644a62e-d8a1-4a43-9260-e0147d955365")
+		(uuid "06616fcd-2aab-48c2-a068-536e9d95818d")
 	)
 	(wire
 		(pts
@@ -2231,16 +2231,6 @@
 			(type default)
 		)
 		(uuid "0dab7d3b-9bf3-49bd-b0d8-5ce09ae20d89")
-	)
-	(wire
-		(pts
-			(xy 213.36 97.79) (xy 213.36 95.25)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "108414ea-fbba-4649-a3c8-c0d53827e711")
 	)
 	(wire
 		(pts
@@ -2371,6 +2361,16 @@
 			(type default)
 		)
 		(uuid "2d3e6651-d2ef-4aff-8f87-12167cfb0bfa")
+	)
+	(wire
+		(pts
+			(xy 204.47 100.33) (xy 199.39 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d8bb856-275c-4f69-89fa-0ecf91b26c8b")
 	)
 	(wire
 		(pts
@@ -2624,6 +2624,16 @@
 	)
 	(wire
 		(pts
+			(xy 204.47 95.25) (xy 204.47 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6c87346a-da69-407e-80e8-e62c02d79317")
+	)
+	(wire
+		(pts
 			(xy 30.48 118.11) (xy 30.48 120.65)
 		)
 		(stroke
@@ -2674,7 +2684,7 @@
 	)
 	(wire
 		(pts
-			(xy 199.39 97.79) (xy 205.74 97.79)
+			(xy 204.47 95.25) (xy 205.74 95.25)
 		)
 		(stroke
 			(width 0)
@@ -2981,6 +2991,16 @@
 			(type default)
 		)
 		(uuid "b30f79e2-20ed-45ad-8a74-8ebc8b8a78c1")
+	)
+	(wire
+		(pts
+			(xy 204.47 102.87) (xy 204.47 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b339d423-8e36-4abd-ad25-6cc7c42e5844")
 	)
 	(wire
 		(pts
@@ -5905,7 +5925,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 209.55 100.33 270)
+		(at 209.55 102.87 270)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -5914,7 +5934,7 @@
 		(dnp no)
 		(uuid "afd0192d-8070-40de-8026-6431a4b05204")
 		(property "Reference" "C712"
-			(at 209.55 96.52 90)
+			(at 213.36 101.6 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5922,7 +5942,7 @@
 			)
 		)
 		(property "Value" "10000PF"
-			(at 209.55 95.25 90)
+			(at 215.138 104.648 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5930,7 +5950,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric"
-			(at 205.74 99.3648 0)
+			(at 205.74 101.9048 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5939,7 +5959,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 209.55 100.33 0)
+			(at 209.55 102.87 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5948,7 +5968,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 209.55 100.33 0)
+			(at 209.55 102.87 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5957,7 +5977,7 @@
 			)
 		)
 		(property "Vendor" "digikey:445-2664-1-ND"
-			(at 109.22 309.88 0)
+			(at 109.22 312.42 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6353,7 +6373,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 209.55 97.79 270)
+		(at 209.55 95.25 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6361,7 +6381,7 @@
 		(dnp no)
 		(uuid "e89f088a-2b56-4029-a01d-0ca2ece0b2cf")
 		(property "Reference" "C711"
-			(at 209.55 101.6 90)
+			(at 213.614 96.774 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6369,7 +6389,7 @@
 			)
 		)
 		(property "Value" "10000PF"
-			(at 209.55 102.87 90)
+			(at 215.138 93.726 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6377,7 +6397,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric"
-			(at 205.74 98.7552 0)
+			(at 205.74 96.2152 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6386,7 +6406,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 209.55 97.79 0)
+			(at 209.55 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6395,7 +6415,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 209.55 97.79 0)
+			(at 209.55 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6404,7 +6424,7 @@
 			)
 		)
 		(property "Vendor" "digikey:445-2664-1-ND"
-			(at 111.76 -111.76 0)
+			(at 111.76 -114.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)


### PR DESCRIPTION
A demo of Kibot automation.  Creation of fab. outputs and more importantly to me, a visual diff.  Includes both diff against a specific git hash to eg. track accumulated change for a variant board, and also diff against a pull request base to assist in reviewing contributes back to the LBL repo.

This PR makes a trivial non-functional change on two schematic pages as a motivating example.

@ldoolitt @ghuangatlbl To be clear.  I am __not__ proposing any move of https://gitlab.com/lbl-boards/zest to github.com.  Please consider this a demo of what I could set up on gitlab if you two would find the output useful.  (cf. [kibot CI docs](https://kibot.readthedocs.io/en/master/usage_with_ci_cd.html), which include gitlab examples)

@PedroJRodriguez fyi.
